### PR TITLE
feat(ecs): add isConatiner property to bounding box

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-    extends: ['@commitlint/config-conventional'],
+    extends: ['@commitlint/config-conventional']
 };

--- a/src/ecs/components/BoundingBoxComponent.ts
+++ b/src/ecs/components/BoundingBoxComponent.ts
@@ -23,6 +23,7 @@ export class BoundingBoxComponent extends BaseComponent implements ICollidableCo
 
     public onCollisionCb: CollisionCallback | undefined;
     public matchContainerTransform: boolean = false;
+    public isContainer: boolean = false;
 
     public get aabb(): AABB { 
 
@@ -41,7 +42,8 @@ export class BoundingBoxComponent extends BaseComponent implements ICollidableCo
     public update(physx: Physx): void {
         physx.pushPhysicalObject({
             object: {
-                aabb: [this.aabb.x, this.aabb.y, this.aabb.width, this.aabb.height]
+                aabb: [this.aabb.x, this.aabb.y, this.aabb.width, this.aabb.height],
+                isContainer: this.isContainer,
             },
             onCollisionCallback: (object: PhysicsObject) => this.onCollision(object),
         });

--- a/src/physx/Physx.ts
+++ b/src/physx/Physx.ts
@@ -1,6 +1,15 @@
+export type AABB = [number, number, number, number];
+
 export interface PhysicsObject {
     // x, y, w, h
-    aabb: [number, number, number, number];
+    aabb: AABB;
+
+    /**
+     * Set to true if the physx object should act as bounday for other objects to not transpass
+     * 
+     * @default false
+     */
+    isContainer?: boolean;
 }
 
 export interface PhysicalObjectCallbackAggregate {
@@ -32,8 +41,8 @@ export class Physx {
         this.physicalWorld.forEach((physicalObject, idx) => {
             this.physicalWorld.forEach((otherPhysicalObject, otherIdx) => {
                 if (idx !== otherIdx && this.checkCollision(physicalObject.object, otherPhysicalObject.object)) {
-                    physicalObject.onCollisionCallback(physicalObject.object);
-                }
+                   physicalObject.onCollisionCallback(physicalObject.object);
+                };
             })
         });
 
@@ -44,6 +53,13 @@ export class Physx {
         const [x1, y1, w1, h1] = objectA.aabb;
         const [x2, y2, w2, h2] = objectB.aabb;
 
+        if (objectA.isContainer) {
+            return this.checkCollisionContainer(objectA, objectB);
+        } else if (objectB.isContainer) {
+            return this.checkCollisionContainer(objectB, objectA);
+        }
+
+        // normal collision detection
         if (
             x1 < x2 + w2 &&
             x1 + w1 > x2 &&
@@ -53,6 +69,22 @@ export class Physx {
             return true;
         }
 
+        return false;
+    }
+
+    private checkCollisionContainer(container: PhysicsObject, objectB: PhysicsObject): boolean {
+        const [x1, y1, w1, h1] = container.aabb;
+        const [x2, y2, w2, h2] = objectB.aabb;
+
+        if (
+            x2 + w2 > x1 + w1 ||
+            y2 + h2 > y1 + h1 ||
+            x2 < x1 ||
+            y2 < y1
+        ) {
+            return true
+        }
+        
         return false;
     }
 }

--- a/test/unit/ecs/components/BoundingBoxComponent.test.ts
+++ b/test/unit/ecs/components/BoundingBoxComponent.test.ts
@@ -86,7 +86,8 @@ describe('ecs/components/BoundingBoxComponent', () => {
 
             expect(physx.physicalWorld).toEqual(expect.arrayContaining([{
                 object: {
-                    aabb: test.expected
+                    aabb: test.expected,
+                    isContainer: false
                 },
                 onCollisionCallback: expect.any(Function)
             }]));
@@ -115,6 +116,36 @@ describe('ecs/components/BoundingBoxComponent', () => {
 
             expect(cbBBComponentA).toHaveBeenCalled();
             expect(cbBBComponentB).toHaveBeenCalled();
-        })
+        });
     });
+
+    describe('.isContainer', () => {
+        it('Should trigger the collision only when objects are outside the bounding box', () => {
+            const cbBBComponentA = jest.fn(() => { });
+            const cbBBComponentB = jest.fn(() => { });
+
+            bbComponent.aabb.x = 5;
+            bbComponent.aabb.y = 5;
+            bbComponent.aabb.height = 5;
+            bbComponent.aabb.width = 5;
+            bbComponent.onCollisionCb = cbBBComponentA;
+            bbComponent.isContainer = true;
+
+            const bbComponentB = new BoundingBoxComponent();
+            bbComponentB.aabb.x = 10;
+            bbComponent.aabb.y = 10;
+            bbComponentB.aabb.width = 4;
+            bbComponentB.aabb.height = 4;
+ 
+            bbComponentB.onCollisionCb = cbBBComponentB;
+
+            bbComponent.update(physx);
+            bbComponentB.update(physx);
+
+            physx.simulate();
+
+            expect(cbBBComponentA).toHaveBeenCalled();
+            expect(cbBBComponentB).toHaveBeenCalled();
+        });
+    })
 })

--- a/test/unit/physx/Physx.test.ts
+++ b/test/unit/physx/Physx.test.ts
@@ -1,4 +1,4 @@
-import { PhysicalObjectCallbackAggregate, PhysicsObject, Physx } from "../../../src"
+import { AABB, PhysicalObjectCallbackAggregate, PhysicsObject, Physx } from "../../../src"
 
 describe('physx/Physx', () => {
     let physx = new Physx();
@@ -68,7 +68,7 @@ describe('physx/Physx', () => {
             
             expect(physicsObject.onCollisionCallback).toHaveBeenCalledWith(physicsObject.object);
             expect(physicsObject2.onCollisionCallback).toHaveBeenCalledWith(physicsObject2.object);
-        })
+        });
 
         it('Should not trigger a collision for object that are not colliding', () => {
             const physicsObject: PhysicalObjectCallbackAggregate = {
@@ -92,6 +92,72 @@ describe('physx/Physx', () => {
             
             expect(physicsObject.onCollisionCallback).not.toHaveBeenCalled();
             expect(physicsObject2.onCollisionCallback).not.toHaveBeenCalled();
+        });
+
+        describe('.isContainer', () => {
+            it.each([{
+                containerAabb: <AABB>[10, 10, 25, 25],
+                otherAabb: <AABB>[45, 45, 25, 25]
+            }, {
+                containerAabb: <AABB>[10, 10, 25, 25],
+                otherAabb: <AABB>[15, 15, 25, 25]
+            }, {
+                containerAabb: <AABB>[10, 10, 25, 25],
+                otherAabb: <AABB>[-5, 0, 115, 115]
+            }, {
+                containerAabb: <AABB>[5, 5, 5, 5],
+                otherAabb: <AABB>[10, 10, 4, 4]
+            }])('Should trigger the Physics object callback if an object is outside the container boundaries', (test) => {
+                const physicsObject: PhysicalObjectCallbackAggregate = {
+                    object: {
+                        aabb: test.containerAabb,
+                        isContainer: true
+                    },
+                    onCollisionCallback: jest.fn(() => { }),
+                };
+
+                const physicsObject2: PhysicalObjectCallbackAggregate = {
+                    object: {
+                        aabb: test.otherAabb
+                    },
+                    onCollisionCallback: jest.fn(() => { }),
+                };
+
+                physx.pushPhysicalObject(physicsObject);
+                physx.pushPhysicalObject(physicsObject2);
+
+                physx.simulate();
+                
+                expect(physicsObject.onCollisionCallback).toHaveBeenCalledWith(physicsObject.object);
+                expect(physicsObject2.onCollisionCallback).toHaveBeenCalledWith(physicsObject2.object);
+            })
+
+            it('Should not trigger a collision for physx objects inside the container', () => {
+                const physicsObject: PhysicalObjectCallbackAggregate = {
+                    object: {
+                        aabb: [10, 10, 25, 25],
+                        isContainer: true
+                    },
+                    onCollisionCallback: jest.fn(() => { }),
+                };
+
+                const physicsObject2: PhysicalObjectCallbackAggregate = {
+                    object: {
+                        aabb: [15, 15, 5, 5]
+                    },
+                    onCollisionCallback: jest.fn(() => { }),
+                };
+
+                physx.pushPhysicalObject(physicsObject);
+                physx.pushPhysicalObject(physicsObject2);
+
+                physx.simulate();
+                
+                expect(physicsObject.onCollisionCallback).not.toHaveBeenCalled();
+                expect(physicsObject2.onCollisionCallback).not.toHaveBeenCalled();
+            });
+
+            it.todo('Should not test collisions against two container objects')
         })
     })
 })


### PR DESCRIPTION
allows to define bounding boxes as containers and trigger the collision on
other physx objects transpassing the boundaries