### PR TITLE
feat(ecs): add optional target in TriggerEntity

### DIFF
--- a/src/ecs/components/BaseComponent.ts
+++ b/src/ecs/components/BaseComponent.ts
@@ -8,9 +8,9 @@ import { IComponent } from "./interfaces";
 export class BaseComponent implements IComponent {
     public readonly uuid = uuid();
 
-    private _container: IEntity | null = null;
+    private _container?: IEntity;
 
-    public getContainer(): IEntity | null {
+    public getContainer(): IEntity | undefined {
         return this._container;
     }
 

--- a/src/ecs/components/interfaces/IComponent.ts
+++ b/src/ecs/components/interfaces/IComponent.ts
@@ -6,6 +6,6 @@ import { IEntity } from "../../entities";
 export interface IComponent {    
     readonly uuid: string;
 
-    getContainer(): IEntity | null;
+    getContainer(): IEntity | undefined;
     setContainer(container: IEntity): void;
 }

--- a/src/ecs/entities/TriggerEntity.ts
+++ b/src/ecs/entities/TriggerEntity.ts
@@ -11,7 +11,7 @@ export interface TriggerEntityProps extends StaticObjectProps {
     /**
      * The target of the trigger component
      */
-    target?: BaseEntity
+    target?: IEntity
 }
 
 /**
@@ -23,7 +23,27 @@ export interface TriggerEntityProps extends StaticObjectProps {
  */
 @Type('TriggerEntity')
 export class TriggerEntity extends StaticObject {
+    private _targetComponent?: BoundingBoxComponent;
 
+    
+    public set target(value: IEntity | undefined) {
+        if (!value) {
+            this._targetComponent = undefined;
+            return;
+        }
+
+        const targetComponent = value.getComponent<BoundingBoxComponent>('BoundingBoxComponent');
+    
+        if (!targetComponent) {
+            throw new Error('Target entity must have a BoundingBox component attached');
+        }
+    
+        this._targetComponent = targetComponent;
+    }
+
+    /**
+     * The target entity that enables the Trigger
+     */
     public get target(): IEntity | undefined {
         return this._targetComponent?.getContainer();
     }
@@ -34,25 +54,13 @@ export class TriggerEntity extends StaticObject {
      */
     public onTriggerCB: Function | null = null;
 
-    private _targetComponent?: BoundingBoxComponent;
-
     /**
      * @param props - the init props
      */
     constructor(props?: TriggerEntityProps) {
         super(props);
 
-
-        if (props?.target) {
-            const targetComponent = props.target.getComponent<BoundingBoxComponent>('BoundingBoxComponent');
-    
-            if (!targetComponent) {
-                throw new Error('Target entity must have a BoundingBox component attached');
-            }
-    
-            this._targetComponent = targetComponent;
-        }
-
+        this.target = props?.target;
         this.boundingBox.onCollisionCb = this.onCollisionHandler.bind(this);
     }
 

--- a/test/unit/ecs/components/BaseComponent.test.ts
+++ b/test/unit/ecs/components/BaseComponent.test.ts
@@ -16,8 +16,8 @@ describe('ecs/components/BaseComponent', () => {
             expect(component.getContainer()).toBe(entity);
         });
 
-        it('Should return null if the component is not attached to an entity', () => {
-            expect(component.getContainer()).toBe(null);
+        it('Should return undefined if the component is not attached to an entity', () => {
+            expect(component.getContainer()).toBe(undefined);
         });
     });
 })

--- a/test/unit/ecs/entities/TriggerEntity.test.ts
+++ b/test/unit/ecs/entities/TriggerEntity.test.ts
@@ -17,8 +17,12 @@ describe('ecs/entities/TriggerEntity', () => {
             ).toThrow('Target entity must have a BoundingBox component attached');
         });
 
-        it('Should assign the target entity', () => {
+        it('Should assign the target entity when defined', () => {
             expect(triggerEntity.target).toBe(otherEntity);  
+        })
+
+        it('Should construct a TriggerEntity without any additional props', () => {
+            expect(new TriggerEntity().target).toBe(undefined);
         })
     })
 

--- a/test/unit/ecs/entities/TriggerEntity.test.ts
+++ b/test/unit/ecs/entities/TriggerEntity.test.ts
@@ -20,9 +20,29 @@ describe('ecs/entities/TriggerEntity', () => {
         it('Should assign the target entity when defined', () => {
             expect(triggerEntity.target).toBe(otherEntity);  
         })
+        
 
         it('Should construct a TriggerEntity without any additional props', () => {
             expect(new TriggerEntity().target).toBe(undefined);
+        })
+    })
+
+    describe('.set target', () => {
+        it('Should throw an excecption if the target entity has no BoundingBox component attached', () => {
+            expect(() => {
+                triggerEntity.target = new BaseEntity();
+            }).toThrow('Target entity must have a BoundingBox component attached');
+        });
+
+        it('Should assign the target entity when defined', () => {
+            const newEntity = new StaticObject();
+            triggerEntity.target = newEntity;
+            expect(triggerEntity.target).toBe(newEntity);  
+        })
+
+        it('Should unset the target when undefined is given', () => {
+            triggerEntity.target = undefined;
+            expect(triggerEntity.target).toBe(undefined);  
         })
     })
 


### PR DESCRIPTION
Closes #270

Adds the ability to change or remove target after trigger entity creation and makes target optional when creating a new TriggerEntity