### PR TITLE
feat(ecs): add dynamic components serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15606,7 +15606,6 @@
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
       "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",

--- a/src/ecs/entities/BaseEntity.ts
+++ b/src/ecs/entities/BaseEntity.ts
@@ -1,12 +1,13 @@
 import { v4 as uuid } from 'uuid';
 import { RegisterUnique, Type, WithType, incrementallyUnique, typeOf, typesOf } from "../../core";
-import { IComponent } from "../components";
+import { ComponentProps, IComponent } from "../components";
 import { EntityProps, IEntity } from "./IEntity";
 
 const ENTITY_TYPE = 'BaseEntity';
 
 export interface BaseEntityProps extends EntityProps {
     name?: string;
+    components?: ComponentProps[];
 }
 
 /**
@@ -18,6 +19,7 @@ export class BaseEntity implements IEntity {
     public readonly uuid = uuid();
 
     private _components: Map<string, IComponent[]> = new Map();
+    private _flattenedComponents: IComponent[] = [];
 
     private _name: string = '';
 
@@ -53,10 +55,11 @@ export class BaseEntity implements IEntity {
      * @param component - the componnt to add to this entity
      */
     public addComponent(component: IComponent): void {
-
         typesOf(component).forEach(type => {
             this._components.set(type, [component, ...this.getComponents(type)])
-        })
+        });
+
+        this._flattenedComponents.push(component);        
         component.setContainer(this);
     }
 
@@ -85,9 +88,12 @@ export class BaseEntity implements IEntity {
     }
 
     public toJson(): WithType<BaseEntityProps> {
+        const components = this._flattenedComponents.map(component => component.toJson());
+
         return {
             __type: typeOf(this),
-            name: this.name
+            name: this.name,
+            components
         }
     }
 }

--- a/src/ecs/entities/BaseEntity.ts
+++ b/src/ecs/entities/BaseEntity.ts
@@ -1,15 +1,12 @@
 import { v4 as uuid } from 'uuid';
 import { RegisterUnique, Type, WithType, incrementallyUnique, typeOf, typesOf } from "../../core";
-import { ComponentProps, IComponent } from "../components";
+import { IComponent } from "../components";
 import { EntityProps, IEntity } from "./IEntity";
 import { create } from '../../core/factory';
 
 const ENTITY_TYPE = 'BaseEntity';
 
-export interface BaseEntityProps extends EntityProps {
-    name?: string;
-    components?: WithType<ComponentProps>[];
-}
+export interface BaseEntityProps extends EntityProps {}
 
 /**
  * @category Entities

--- a/src/ecs/entities/BaseEntity.ts
+++ b/src/ecs/entities/BaseEntity.ts
@@ -2,12 +2,13 @@ import { v4 as uuid } from 'uuid';
 import { RegisterUnique, Type, WithType, incrementallyUnique, typeOf, typesOf } from "../../core";
 import { ComponentProps, IComponent } from "../components";
 import { EntityProps, IEntity } from "./IEntity";
+import { create } from '../../core/factory';
 
 const ENTITY_TYPE = 'BaseEntity';
 
 export interface BaseEntityProps extends EntityProps {
     name?: string;
-    components?: ComponentProps[];
+    components?: WithType<ComponentProps>[];
 }
 
 /**
@@ -29,6 +30,11 @@ export class BaseEntity implements IEntity {
         } else {
             this.name = incrementallyUnique(typeOf(this));
         }
+
+        props?.components?.forEach(componentProps => {
+            const component = create<IComponent>(componentProps.__type, componentProps)
+            this.addComponent(component);
+        });
     }
 
     /**

--- a/src/ecs/entities/GameObject.ts
+++ b/src/ecs/entities/GameObject.ts
@@ -1,4 +1,4 @@
-import { RegisterUnique, Type, WithType } from "../../core";
+import { RegisterUnique, Type } from "../../core";
 import { MaterialComponent, MaterialComponentProps, ShapeComponent, ShapeComponentProps, TransformComponent, TransformComponentProps } from "../components";
 import { BaseEntity, BaseEntityProps } from "./BaseEntity";
 
@@ -31,9 +31,29 @@ export interface GameObjectProps extends BaseEntityProps {
 @Type(ENTITY_TYPE)
 @RegisterUnique(ENTITY_TYPE)
 export class GameObject extends BaseEntity {
-    public transform: TransformComponent;
-    public shape: ShapeComponent;
-    public material: MaterialComponent;
+    public get transform(): TransformComponent {
+        return this.getComponent<TransformComponent>('TransformComponent')!;
+    }
+
+    public set transform(value: TransformComponent) {
+        this.addComponent(value);
+    }
+
+    public get material(): MaterialComponent {
+        return this.getComponent<MaterialComponent>('MaterialComponent')!;
+    }
+
+    public set material(value: MaterialComponent) {
+        this.addComponent(value);
+    }
+
+    public get shape(): ShapeComponent {
+        return this.getComponent<ShapeComponent>('ShapeComponent')!;
+    }
+
+    public set shape(value: ShapeComponent) {
+        this.addComponent(value);
+    }
 
     /**
      * 
@@ -42,12 +62,16 @@ export class GameObject extends BaseEntity {
     constructor(props?: GameObjectProps) {
         super(props);
 
-        this.transform = new TransformComponent(props?.transform);
-        this.shape = new ShapeComponent(props?.shape);
-        this.material = new MaterialComponent(props?.material);
+        if (!this.transform) {
+            this.transform = new TransformComponent(props?.transform);
+        }
 
-        this.addComponent(this.transform);
-        this.addComponent(this.shape);
-        this.addComponent(this.material);
+        if(!this.shape) {
+            this.shape = new ShapeComponent(props?.shape);
+        }
+
+        if(!this.material) {
+            this.material = new MaterialComponent(props?.material);
+        }
     }
 }

--- a/src/ecs/entities/GameObject.ts
+++ b/src/ecs/entities/GameObject.ts
@@ -50,13 +50,4 @@ export class GameObject extends BaseEntity {
         this.addComponent(this.shape);
         this.addComponent(this.material);
     }
-
-    public toJson(): WithType<GameObjectProps> {
-        return {
-            ...super.toJson(),
-            transform: this.transform.toJson(),
-            shape: this.shape.toJson(),
-            material: this.material.toJson()
-        }
-    }
 }

--- a/src/ecs/entities/IEntity.ts
+++ b/src/ecs/entities/IEntity.ts
@@ -1,7 +1,9 @@
 import { WithType } from "../../core";
-import { IComponent } from "../components";
+import { ComponentProps, IComponent } from "../components";
 
 export interface EntityProps {
+    name?: string;
+    components?: WithType<ComponentProps>[];
 }
 
 /**

--- a/src/ecs/entities/StaticObject.ts
+++ b/src/ecs/entities/StaticObject.ts
@@ -34,12 +34,4 @@ export class StaticObject extends GameObject {
         
         this.addComponent(this.boundingBox);
     }
-
-
-    public toJson(): WithType<StaticObjectProps> {
-        return {
-            ...super.toJson(),
-            boundingBox: this.boundingBox.toJson()
-        }
-    }
 }

--- a/src/ecs/entities/StaticObject.ts
+++ b/src/ecs/entities/StaticObject.ts
@@ -1,5 +1,5 @@
-import { RegisterUnique, Type, WithType } from "../../core";
-import { BoundingBoxComponent, BoundingBoxComponentProps } from "../components";
+import { RegisterUnique, Type } from "../../core";
+import { BoundingBoxComponent, BoundingBoxComponentProps, ComponentProps } from "../components";
 import { GameObject, GameObjectProps } from "./GameObject";
 
 const ENTITY_TYPE = 'StaticObject';
@@ -21,7 +21,13 @@ export interface StaticObjectProps extends GameObjectProps {
 @Type(ENTITY_TYPE)
 @RegisterUnique(ENTITY_TYPE)
 export class StaticObject extends GameObject {
-    public boundingBox: BoundingBoxComponent;
+    public get boundingBox(): BoundingBoxComponent {
+        return this.getComponent<BoundingBoxComponent>('BoundingBoxComponent')!;
+    }
+
+    public set boundingBox(value: BoundingBoxComponent) {
+        this.addComponent(value);
+    }
 
     /**
      * 
@@ -30,8 +36,8 @@ export class StaticObject extends GameObject {
     constructor(props?: StaticObjectProps) {
         super(props);
 
-        this.boundingBox = new BoundingBoxComponent(props?.boundingBox);
-        
-        this.addComponent(this.boundingBox);
+        if(!this.boundingBox) {
+            this.boundingBox = new BoundingBoxComponent(props?.boundingBox);
+        }
     }
 }

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -2,7 +2,6 @@ import { AnimationSystem, HierarchySystem, InputSystem, PhysicsSystem, RenderSys
 import { Physx } from "../physx";
 import { CanvasDevice, ImageLoader, DOMImageLoader, KeyboardDevice } from "../platform";
 import { Renderer } from "../renderer";
-import { Scene } from "./Scene";
 
 /**
  * @category Engine

--- a/test/unit/__mocks__/assets/EntitiesWithComponents.scene.json
+++ b/test/unit/__mocks__/assets/EntitiesWithComponents.scene.json
@@ -2,36 +2,43 @@
     "entities": {
         "testEntity5": {
             "__type": "GameObject",
-            "transform": {
-                "position": {
-                    "x": 1,
-                    "y": 2
-                },
-                "size": {
-                    "width": 100,
-                    "height": 50
+            "components": [
+                {
+                    "__type": "Transform",
+                    "position": {
+                        "x": 1,
+                        "y": 2
+                    },
+                    "size": {
+                        "width": 100,
+                        "height": 50
+                    }
                 }
-            }
+            ]
         },
         "testEntity6": {
             "__type": "GameObject",
-            "transform": {
-                "position": {
-                    "x": 10,
-                    "y": 20
+            "components": [
+                {
+                    "__type": "Transform",
+                    "position": {
+                        "x": 3,
+                        "y": 4
+                    },
+                    "size": {
+                        "width": 200,
+                        "height": 100
+                    }
                 },
-                "size": {
-                    "width": 100,
-                    "height": 50
+                {
+                    "__type": "Material",
+                    "diffuseColor": {
+                        "r": 0,
+                        "g": 255,
+                        "b": 0
+                    }
                 }
-            },
-            "material": {
-                "diffuseColor": {
-                    "r": 255,
-                    "g": 0,
-                    "b": 0
-                }
-            }
+            ]
         }
     }
 }

--- a/test/unit/__mocks__/assets/EntitiesWithComponents.scene.json
+++ b/test/unit/__mocks__/assets/EntitiesWithComponents.scene.json
@@ -4,7 +4,7 @@
             "__type": "GameObject",
             "components": [
                 {
-                    "__type": "Transform",
+                    "__type": "TransformComponent",
                     "position": {
                         "x": 1,
                         "y": 2
@@ -20,18 +20,18 @@
             "__type": "GameObject",
             "components": [
                 {
-                    "__type": "Transform",
+                    "__type": "TransformComponent",
                     "position": {
-                        "x": 3,
-                        "y": 4
+                        "x": 10,
+                        "y": 20
                     },
                     "size": {
-                        "width": 200,
-                        "height": 100
+                        "width": 100,
+                        "height": 50
                     }
                 },
                 {
-                    "__type": "Material",
+                    "__type": "MaterialComponent",
                     "diffuseColor": {
                         "r": 0,
                         "g": 255,

--- a/test/unit/ecs/entities/BaseEntity.test.ts
+++ b/test/unit/ecs/entities/BaseEntity.test.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseEntity, TransformComponent, Type } from "../../../../src";
+import { BaseComponent, BaseEntity, TransformComponent, Type, Vec2 } from "../../../../src";
 
 describe('ecs/entities/BaseEntity', () => {
     let baseEntity: BaseEntity;
@@ -12,10 +12,21 @@ describe('ecs/entities/BaseEntity', () => {
             expect(baseEntity.name).toEqual('BaseEntity1');
         });
 
-        it('Should use an incrementally unique game if more entities with the same name exist and default name is used', () => {    
+        it('Should use an incrementally unique game if more entities with the same name exist and default name is used', () => {
             const currentCount = parseInt(baseEntity.name.split('BaseEntity')[1]);
-            expect(new BaseEntity().name).toEqual('BaseEntity' +  (currentCount + 1));
-        })
+            expect(new BaseEntity().name).toEqual('BaseEntity' + (currentCount + 1));
+        });
+
+        it('Should register comoponents if provided', () => {
+            const testComponent = new TransformComponent();
+            testComponent.position = new Vec2(10, 10);
+
+            baseEntity = new BaseEntity({
+                components: [testComponent.toJson()]
+            });
+
+            expect(baseEntity.getComponent<TransformComponent>('TransformComponent')?.toJson()).toEqual(testComponent.toJson());
+        });
     })
     
     describe('.addComponent()', () => {

--- a/test/unit/ecs/entities/BaseEntity.test.ts
+++ b/test/unit/ecs/entities/BaseEntity.test.ts
@@ -1,4 +1,4 @@
-import { BaseComponent, BaseEntity, Type } from "../../../../src";
+import { BaseComponent, BaseEntity, TransformComponent, Type } from "../../../../src";
 
 describe('ecs/entities/BaseEntity', () => {
     let baseEntity: BaseEntity;
@@ -74,15 +74,39 @@ describe('ecs/entities/BaseEntity', () => {
     })
 
     describe('.toJson()', () => {
-        it('Should return a json representetion of the BaseEntity', () => {
-            const testComponent = new BaseComponent();
-            baseEntity.addComponent(testComponent);
+        it('Should serialize the name and type of the entity', () => {
             baseEntity.name = 'BaseEntity1234';
 
             expect(baseEntity.toJson()).toEqual({
                 __type: 'BaseEntity',
-                name: 'BaseEntity1234'
+                name: 'BaseEntity1234',
+                components: []
             });
-        })
+        });
+
+        it('Should serialize all components in the entity', () => {
+            const testComponentA = new BaseComponent();
+            const testComponentB = new BaseComponent();
+
+            baseEntity.addComponent(testComponentA);
+            baseEntity.addComponent(testComponentB);
+
+            expect(baseEntity.toJson()).toEqual(expect.objectContaining({
+                components: expect.arrayContaining([
+                    testComponentB.toJson(),
+                    testComponentA.toJson()
+                ])
+            }));
+        });
+
+        it('Should serialize the same component only once', () => {
+            const testComponent = new TransformComponent();
+            
+            baseEntity.addComponent(testComponent);
+
+            expect(baseEntity.toJson()).toEqual(expect.objectContaining({
+                components: [testComponent.toJson()]
+            }));
+        });
     })
 })

--- a/test/unit/ecs/entities/GameObject.test.ts
+++ b/test/unit/ecs/entities/GameObject.test.ts
@@ -1,4 +1,4 @@
-import { GameObject, MaterialComponentProps, PrimitiveType, Rgb, ShapeComponentProps, TransformComponentProps, Vec2 } from "../../../../src"
+import { ComponentProps, GameObject, GameObjectProps, IComponent, MaterialComponent, MaterialComponentProps, PrimitiveType, Rgb, ShapeComponent, ShapeComponentProps, TransformComponent, TransformComponentProps, Vec2, WithType } from "../../../../src"
 
 describe('ecs/entities/GameObject', () => {
     let gameObject: GameObject;
@@ -69,7 +69,36 @@ describe('ecs/entities/GameObject', () => {
             })
 
             expect(gameObject.material).toEqual(expect.objectContaining(materialConfig))
-        })
+        });
+
+        it('Should support dynamic components registration', () => {
+            const transformComponent = new TransformComponent({
+                position: new Vec2(10, 10),
+            });
+
+            const gameObject = new GameObject({
+                components: [
+                    transformComponent.toJson(),
+                ]
+            });
+
+            expect(gameObject.getComponent<TransformComponent>('TransformComponent')?.toJson()).toEqual(transformComponent.toJson());
+        });
+
+        it.each([
+            { transform: new TransformComponent().toJson() },
+            { material: new MaterialComponent().toJson() },
+            { shape: new ShapeComponent().toJson() }
+        ])('Should register the same component only once', (partialConfig: Partial<GameObjectProps>) => {
+            let config = {
+                ...partialConfig,
+                components: Object.values(partialConfig).map(c => c as WithType<ComponentProps>)
+            };
+
+            const gameObject = new GameObject(config);
+
+            expect(gameObject.toJson().components).toHaveLength(3); // transform, material, shape
+        });
     })
 
     describe('.toJson()', () => {

--- a/test/unit/ecs/entities/GameObject.test.ts
+++ b/test/unit/ecs/entities/GameObject.test.ts
@@ -81,10 +81,12 @@ describe('ecs/entities/GameObject', () => {
             expect(json).toEqual({
                 __type: 'GameObject',
                 name: gameObject.name,
-                transform: gameObject.transform.toJson(),
-                material: gameObject.material.toJson(),
-                shape: gameObject.shape.toJson()
+                components: expect.arrayContaining([
+                    gameObject.transform.toJson(),
+                    gameObject.material.toJson(),
+                    gameObject.shape.toJson()
+                ])
             })
-        })
+        });
     })
 })

--- a/test/unit/ecs/entities/StaticObject.test.ts
+++ b/test/unit/ecs/entities/StaticObject.test.ts
@@ -1,4 +1,4 @@
-import { BoundingBoxComponentProps, GameObject, StaticObject } from "../../../../src"
+import { BoundingBoxComponent, BoundingBoxComponentProps, GameObject, StaticObject } from "../../../../src"
 
 describe('ecs/entities/StaticObject', () => {
     let staticObject = new StaticObject();
@@ -24,10 +24,10 @@ describe('ecs/entities/StaticObject', () => {
 
         it('Should create a bounding box component with given configuration', () => {
             const bbConfig: BoundingBoxComponentProps = {
-                aabb: {x: 10, y: 5, width: 10, height: 5},
-                isContainer: true, 
+                aabb: { x: 10, y: 5, width: 10, height: 5 },
+                isContainer: true,
                 matchContainerTransform: false,
-                onCollisionCb: () => {}
+                onCollisionCb: () => { }
             }
             
             const staticObject = new StaticObject({
@@ -37,7 +37,25 @@ describe('ecs/entities/StaticObject', () => {
             expect(staticObject.boundingBox.aabb).toEqual(bbConfig.aabb);
             expect(staticObject.boundingBox.isContainer).toEqual(bbConfig.isContainer);
             expect(staticObject.boundingBox.matchContainerTransform).toEqual(bbConfig.matchContainerTransform);
-        })
+        });
+
+        it('Should register the same component only once', () => {
+            const bbCompoonent = new BoundingBoxComponent({
+                aabb: { x: 10, y: 5, width: 10, height: 5 },
+                isContainer: true,
+                matchContainerTransform: false,
+                onCollisionCb: () => { }
+            })
+
+            const staticObject = new StaticObject({
+                boundingBox: bbCompoonent.toJson(),
+                components: [
+                    bbCompoonent.toJson()
+                ]
+            });
+
+            expect(staticObject.toJson().components).toHaveLength(4); // transform, material, shape, boundingBox
+        });
     })
 
     describe('.toJson()', () => {

--- a/test/unit/ecs/entities/StaticObject.test.ts
+++ b/test/unit/ecs/entities/StaticObject.test.ts
@@ -45,10 +45,12 @@ describe('ecs/entities/StaticObject', () => {
             expect(staticObject.toJson()).toEqual({
                 __type: 'StaticObject',
                 name: staticObject.name,
-                shape: staticObject.shape.toJson(),
-                material: staticObject.material.toJson(),
-                transform: staticObject.transform.toJson(),
-                boundingBox: staticObject.boundingBox.toJson()
+                components: expect.arrayContaining([
+                    staticObject.transform.toJson(),
+                    staticObject.material.toJson(),
+                    staticObject.shape.toJson(),
+                    staticObject.boundingBox.toJson()
+                ]),
             });
         })
     })

--- a/test/unit/ecs/entities/TriggerEntity.test.ts
+++ b/test/unit/ecs/entities/TriggerEntity.test.ts
@@ -18,13 +18,29 @@ describe('ecs/entities/TriggerEntity', () => {
         });
 
         it('Should assign the target entity when defined', () => {
-            expect(triggerEntity.target).toBe(otherEntity);  
-        })
-        
+            expect(triggerEntity.target).toBe(otherEntity);
+        });
 
         it('Should construct a TriggerEntity without any additional props', () => {
             expect(new TriggerEntity().target).toBe(undefined);
-        })
+        });
+
+        it('Should register the same component only once', () => {
+            const targetEntity = new StaticObject({
+                boundingBox: {
+                    aabb: { x: 0, y: 0, width: 10, height: 10 },
+                    isContainer: true,
+                    matchContainerTransform: false,
+                    onCollisionCb: () => { }
+                }
+            });
+
+            const triggerEntity = new TriggerEntity({
+                target: targetEntity,
+            });
+        
+            expect(triggerEntity.toJson().components).toHaveLength(4);
+        });
     })
 
     describe('.set target', () => {

--- a/test/unit/engine/Scene.test.ts
+++ b/test/unit/engine/Scene.test.ts
@@ -288,51 +288,12 @@ describe('/game/Scene', () => {
     })
 
     describe('.loadFromJson()', () => {
-        it('Should load all entities from the scene', async () => {
-            scene.loadFromJson((await defaultEntitiesScene).default);
-
-            expect(scene.entities).toEqual([
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity1',
-                }),
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity2',
-                })
-            ]);
-        })
-
         it('Should load the entities configuration as well', async () => {
-            scene.loadFromJson((await entitiesWithComponents).default);
+            const sceneJson = (await entitiesWithComponents).default;
 
-            expect(scene.entities).toEqual([
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity5',
-                    transform: expect.objectContaining({
-                        position: new Vec2(1, 2),
-                        size: { width: 100, height: 50 }
-                    }),
-                    shape: expect.objectContaining({
-                        shapeType: PrimitiveType.Rectangle
-                    })
-                }),
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity6',
-                    transform: expect.objectContaining({
-                        position: new Vec2(10, 20),
-                        size: { width: 100, height: 50 }
-                    }),
-                    shape: expect.objectContaining({
-                        shapeType: PrimitiveType.Rectangle
-                    }),
-                    material: expect.objectContaining({
-                        diffuseColor: new Rgb(255)
-                    })
-                })
-            ]);
+            scene.loadFromJson(sceneJson);
+
+            expect(scene.toJson()).toMatchSnapshot("SceneSnapshot");
         });
 
         it('Should load the entities name when loading a scene', () => {
@@ -399,33 +360,7 @@ describe('/game/Scene', () => {
 
             await scene.loadFromFile('test.scene.json');
 
-            expect(scene.entities).toEqual([
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity5',
-                    transform: expect.objectContaining({
-                        position: new Vec2(1, 2),
-                        size: { width: 100, height: 50 }
-                    }),
-                    shape: expect.objectContaining({
-                        shapeType: PrimitiveType.Rectangle
-                    })
-                }),
-                expect.objectContaining({
-                    __type: 'GameObject',
-                    _name: 'testEntity6',
-                    transform: expect.objectContaining({
-                        position: new Vec2(10, 20),
-                        size: { width: 100, height: 50 }
-                    }),
-                    shape: expect.objectContaining({
-                        shapeType: PrimitiveType.Rectangle
-                    }),
-                    material: expect.objectContaining({
-                        diffuseColor: new Rgb(255)
-                    })
-                })
-            ]);
+            expect(scene.toJson()).toMatchSnapshot("SceneSnapshot")
         });
 
         it('Should load the entities name when loading a scene', async () => {

--- a/test/unit/engine/__snapshots__/Scene.test.ts.snap
+++ b/test/unit/engine/__snapshots__/Scene.test.ts.snap
@@ -1,0 +1,227 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`/game/Scene .loadFromFile() Should load the entities configuration as well: SceneSnapshot 1`] = `
+{
+  "entities": {
+    "testEntity5": {
+      "__type": "GameObject",
+      "components": [
+        {
+          "__type": "TransformComponent",
+          "depthIndex": 0,
+          "position": Vec2 {
+            "x": 1,
+            "y": 2,
+          },
+          "size": {
+            "height": 50,
+            "width": 100,
+          },
+          "velocity": Vec2 {
+            "x": 0,
+            "y": 0,
+          },
+        },
+        {
+          "__type": "ShapeComponent",
+          "isWireframe": false,
+          "shapeType": 0,
+          "transform": {
+            "__type": "TransformComponent",
+            "depthIndex": 0,
+            "position": Vec2 {
+              "x": 1,
+              "y": 2,
+            },
+            "size": {
+              "height": 50,
+              "width": 100,
+            },
+            "velocity": Vec2 {
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "__type": "MaterialComponent",
+          "diffuseColor": {
+            "b": 216,
+            "g": 108,
+            "r": 209,
+          },
+          "diffuseTexturePath": undefined,
+          "opacity": 100,
+        },
+      ],
+      "name": "testEntity5",
+    },
+    "testEntity6": {
+      "__type": "GameObject",
+      "components": [
+        {
+          "__type": "TransformComponent",
+          "depthIndex": 0,
+          "position": Vec2 {
+            "x": 10,
+            "y": 20,
+          },
+          "size": {
+            "height": 50,
+            "width": 100,
+          },
+          "velocity": Vec2 {
+            "x": 0,
+            "y": 0,
+          },
+        },
+        {
+          "__type": "MaterialComponent",
+          "diffuseColor": {
+            "b": 0,
+            "g": 255,
+            "r": 0,
+          },
+          "diffuseTexturePath": undefined,
+          "opacity": 100,
+        },
+        {
+          "__type": "ShapeComponent",
+          "isWireframe": false,
+          "shapeType": 0,
+          "transform": {
+            "__type": "TransformComponent",
+            "depthIndex": 0,
+            "position": Vec2 {
+              "x": 10,
+              "y": 20,
+            },
+            "size": {
+              "height": 50,
+              "width": 100,
+            },
+            "velocity": Vec2 {
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+      "name": "testEntity6",
+    },
+  },
+}
+`;
+
+exports[`/game/Scene .loadFromJson() Should load the entities configuration as well: SceneSnapshot 1`] = `
+{
+  "entities": {
+    "testEntity5": {
+      "__type": "GameObject",
+      "components": [
+        {
+          "__type": "TransformComponent",
+          "depthIndex": 0,
+          "position": Vec2 {
+            "x": 1,
+            "y": 2,
+          },
+          "size": {
+            "height": 50,
+            "width": 100,
+          },
+          "velocity": Vec2 {
+            "x": 0,
+            "y": 0,
+          },
+        },
+        {
+          "__type": "ShapeComponent",
+          "isWireframe": false,
+          "shapeType": 0,
+          "transform": {
+            "__type": "TransformComponent",
+            "depthIndex": 0,
+            "position": Vec2 {
+              "x": 1,
+              "y": 2,
+            },
+            "size": {
+              "height": 50,
+              "width": 100,
+            },
+            "velocity": Vec2 {
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+        {
+          "__type": "MaterialComponent",
+          "diffuseColor": {
+            "b": 216,
+            "g": 108,
+            "r": 209,
+          },
+          "diffuseTexturePath": undefined,
+          "opacity": 100,
+        },
+      ],
+      "name": "testEntity5",
+    },
+    "testEntity6": {
+      "__type": "GameObject",
+      "components": [
+        {
+          "__type": "TransformComponent",
+          "depthIndex": 0,
+          "position": Vec2 {
+            "x": 10,
+            "y": 20,
+          },
+          "size": {
+            "height": 50,
+            "width": 100,
+          },
+          "velocity": Vec2 {
+            "x": 0,
+            "y": 0,
+          },
+        },
+        {
+          "__type": "MaterialComponent",
+          "diffuseColor": {
+            "b": 0,
+            "g": 255,
+            "r": 0,
+          },
+          "diffuseTexturePath": undefined,
+          "opacity": 100,
+        },
+        {
+          "__type": "ShapeComponent",
+          "isWireframe": false,
+          "shapeType": 0,
+          "transform": {
+            "__type": "TransformComponent",
+            "depthIndex": 0,
+            "position": Vec2 {
+              "x": 10,
+              "y": 20,
+            },
+            "size": {
+              "height": 50,
+              "width": 100,
+            },
+            "velocity": Vec2 {
+              "x": 0,
+              "y": 0,
+            },
+          },
+        },
+      ],
+      "name": "testEntity6",
+    },
+  },
+}
+`;


### PR DESCRIPTION
Closes #552 

Components are now serialized as `components[]` array instead of each single component having specific keys. See  https://github.com/RuggeroVisintin/SparkEngineWeb/blob/main/docs/architecture/decisions/0003-entity-serialization.md
